### PR TITLE
input mask accessibility improvement

### DIFF
--- a/src/app/components/inputmask/inputmask.ts
+++ b/src/app/components/inputmask/inputmask.ts
@@ -40,7 +40,7 @@ export const INPUTMASK_VALUE_ACCESSOR: any = {
 @Component({
     selector: 'p-inputMask',
     template: `<input #input pInputText [attr.id]="inputId" [attr.type]="type" [attr.name]="name" [ngStyle]="style" [ngClass]="styleClass" [attr.placeholder]="placeholder"
-        [attr.size]="size" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [disabled]="disabled" [readonly]="readonly" [attr.required]="required"
+        [attr.size]="size" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [attr.aria-label]="ariaLabel" [attr.aria-required]="ariaRequired" [disabled]="disabled" [readonly]="readonly" [attr.required]="required"
         (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (keydown)="onKeyDown($event)" (keypress)="onKeyPress($event)" [attr.autofocus]="autoFocus"
         (input)="onInput($event)" (paste)="handleInputChange($event)">`,
     host: {
@@ -70,6 +70,10 @@ export class InputMask implements OnInit,OnDestroy,ControlValueAccessor {
     @Input() maxlength: number;
 
     @Input() tabindex: string;
+    
+    @Input() ariaLabel: string;
+     
+    @Input() ariaRequired: boolean;
 
     @Input() disabled: boolean;
 


### PR DESCRIPTION
### Defect Fixes
This PR addresses the accessibility improvements outlined in [issue #6465 ](https://github.com/primefaces/primeng/issues/6465).

### Feature Requests
This PR adds "aria-label" and "aria-required" attributes to applicable PrimeNG input components. The changes are small, but impactful for visually impaired users with screen readers. This will improve PrimeNG's overall accessibility.

The biggest change made to any of the input components was the addition of the following code to the typescript:

The addition of [attr.aria-label]="ariaLabel" [attr.aria-required]="ariaRequired" to the input element in the template and the addition of @Input() ariaLabel: string; and @Input() ariaRequired: boolean; to the list of inputs.

NOTE - The "required" attribute does a lot of what the "aria-required" attribute does, but the latter is still useful for user agents that do not yet support HTML5.